### PR TITLE
Modified the logic in GraphAutoma to conditionally trace back the kickoff_worker_key based on debug settings, enhancing debugging capabilities.

### DIFF
--- a/bridgic-core/bridgic/core/automa/graph_automa.py
+++ b/bridgic-core/bridgic/core/automa/graph_automa.py
@@ -135,7 +135,7 @@ class _KickoffInfo(BaseModel):
     # The key of the worker that is going to be kicked off.
     worker_key: str
     # Worker key or the container "__automa__"
-    last_kickoff: str
+    last_kickoff: Optional[str]
     # Whether the kickoff is triggered by ferry_to() initiated by developers.
     from_ferry: bool = False
     # Whether the run is finished.
@@ -169,7 +169,7 @@ class _SetOutputWorkerDeferredTask(BaseModel):
 
 class _FerryDeferredTask(BaseModel):
     ferry_to_worker_key: str
-    kickoff_worker_key: str
+    kickoff_worker_key: Optional[str]
     args: Tuple[Any, ...]
     kwargs: Dict[str, Any]
 
@@ -1009,7 +1009,9 @@ class GraphAutoma(Automa, metaclass=GraphAutomaMeta):
         ```
         """
         # TODO: check worker_key is valid, maybe deferred check...
-        kickoff_worker_key: str = self._trace_back_kickoff_worker_key_from_stack()
+        running_options = self._get_top_running_options()
+        # if debug is enabled, trace back the kickoff worker key from stacktrace.
+        kickoff_worker_key: str = self._trace_back_kickoff_worker_key_from_stack() if running_options.debug else None
         deferred_task = _FerryDeferredTask(
             ferry_to_worker_key=worker_key,
             kickoff_worker_key=kickoff_worker_key,


### PR DESCRIPTION
- Changed last_kickoff to Optional[str] to allow for None values.
- Updated kickoff_worker_key in _FerryDeferredTask to Optional[str] for improved flexibility.
- Modified the logic in GraphAutoma to conditionally trace back the kickoff_worker_key based on debug settings, enhancing debugging capabilities.