### PR TITLE
Refactor: refact serialization codes and fix object creation before calling load_from_dict.

### DIFF
--- a/bridgic-core/bridgic/core/automa/automa.py
+++ b/bridgic-core/bridgic/core/automa/automa.py
@@ -10,7 +10,7 @@ from bridgic.core.automa.worker import Worker
 class RunningOptions(BaseModel):
     debug: bool = False
 
-class Automa(Worker, metaclass=ABCMeta):
+class Automa(Worker):
     _running_options: RunningOptions
 
     def __init__(self, name: str = None):
@@ -26,12 +26,14 @@ class Automa(Worker, metaclass=ABCMeta):
     def dump_to_dict(self) -> Dict[str, Any]:
         state_dict = super().dump_to_dict()
         state_dict["name"] = self.name
+        state_dict["running_options"] = self._running_options
         return state_dict
 
     @override
     def load_from_dict(self, state_dict: Dict[str, Any]) -> None:
         super().load_from_dict(state_dict)
         self.name = state_dict["name"]
+        self._running_options = state_dict["running_options"]
 
     def is_top_level(self) -> bool:
         """

--- a/bridgic-core/bridgic/core/automa/graph_automa.py
+++ b/bridgic-core/bridgic/core/automa/graph_automa.py
@@ -6,8 +6,8 @@ from inspect import Parameter, _ParameterKind
 import json
 import threading
 import uuid
-from abc import ABCMeta
-from typing import Any, List, Dict, Set, Mapping, Callable, Tuple, Optional, Literal, Union
+from typing import _ProtocolMeta
+from typing import Any, List, Dict, Set, Mapping, Callable, Tuple, Optional, Literal, Union, ClassVar
 from types import MethodType
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -25,7 +25,7 @@ from bridgic.core.automa.worker.callable_worker import CallableWorker
 from bridgic.core.automa.interaction import Event, FeedbackSender, EventHandlerType, InteractionFeedback, Feedback, Interaction, InteractionException
 from bridgic.core.automa.serialization import Snapshot
 from bridgic.core.automa.arguments_descriptor import RuntimeContext, injector
-import bridgic.core.serialization.msgpackx as msgpackx
+from bridgic.core.utils import msgpackx
 
 class _GraphAdaptedWorker(Worker):
     """
@@ -174,7 +174,7 @@ class _FerryDeferredTask(BaseModel):
     args: Tuple[Any, ...]
     kwargs: Dict[str, Any]
 
-class GraphAutomaMeta(ABCMeta):
+class GraphAutomaMeta(_ProtocolMeta):
     """
     This metaclass is used to:
         - Correctly handle inheritence of pre-defined workers during GraphAutoma class inheritence, 
@@ -360,28 +360,28 @@ class GraphAutoma(Automa, metaclass=GraphAutomaMeta):
     """
 
     # The initial topology defined by @worker functions.
-    _registered_worker_funcs: Dict[str, Callable] = {}
+    _registered_worker_funcs: ClassVar[Dict[str, Callable]] = {}
 
-    # [IMPORTANT] 
-    # The whole states of the Automa are divided into two main parts:
-    #
-    # [Part One: Topology-Related Runtime States] The runtime states related to topology changes.
-    # -- Nodes: workers (A Worker can be another Automa): {_workers}
-    # -- Edges: Dependencies between workers: {dependencies in _workers, _worker_forwards}
-    # -- Worker Dynamics: the dynamic in-degrees of each workers. {_workers_dynamic_states}
-    # -- Configurations: Start workers, output worker, args_mapping_rule, etc. {_output_worker_key, is_start and args_mapping_rule in _workers}
-    # -- Deferred Tasks: {_topology_change_deferred_tasks, _set_output_worker_deferred_task}
-    #
-    # [Part Two: Task-Related Runtime States] The runtime states related to task execution.
-    # -- Current kickoff workers list. {_current_kickoff_workers}
-    # -- Running & Ferry Tasks list. {_running_tasks, _ferry_deferred_tasks}
-    # -- Automa input buffer. {_input_buffer}
-    # -- Output buffer and local space for each worker. {in _workers}
-    # -- Ongoing human interactions... {_ongoing_interactions}
-    # -- Other runtime states...
+    # IMPORTANT: The entire states of a GraphAutoma instance include 2 part:
+    # 
+    # Part-1 (for the states of topology structure):
+    #   1. Inner worker instances: self._workers
+    #   2. Relations between worker: self._worker_forwards
+    #   3. Dynamic states that serve as trigger of execution of workers: self._workers_dynamic_states
+    #   4. Execution result of inner workers: self._worker_output
+    #   5. Configurations of this automa instance: self._output_worker_key
+    # 
+    # Part-2 (for the states of running states):
+    #   1. Records of Workers that are going to be kicked off: self._current_kickoff_workers
+    #   2. Records of running or deferred tasks:
+    #      - self._running_tasks
+    #      - self._topology_change_deferred_tasks
+    #      - self._ferry_deferred_tasks
+    #      - self._set_output_worker_deferred_task
+    #   3. Buffers of automa inputs: self._input_buffer
+    #   4. Ongoing human interactions: self._ongoing_interactions
+    #   ...
 
-    # Note: Just declarations, NOT instances!!!
-    # So do not initialize them here!!!
     _workers: Dict[str, _GraphAdaptedWorker]
     _worker_output: Dict[str, Any]
     _worker_forwards: Dict[str, List[str]]
@@ -538,37 +538,59 @@ class GraphAutoma(Automa, metaclass=GraphAutomaMeta):
     @override
     def dump_to_dict(self) -> Dict[str, Any]:
         state_dict = super().dump_to_dict()
-        # collect states to serialize 
+
         state_dict["name"] = self.name
-        # TODO: serialize the workers, including the outbuf of each worker
-        state_dict["workers"] = self._workers
         state_dict["automa_running"] = self._automa_running
+        state_dict["output_worker_key"] = self._output_worker_key
+
+        # States related to workers.
+        state_dict["workers"] = self._workers
         state_dict["worker_forwards"] = self._worker_forwards
         state_dict["workers_dynamic_states"] = self._workers_dynamic_states
-        state_dict["output_worker_key"] = self._output_worker_key
-        # TODO: args && kwargs must be serializable in order to serialize _current_kickoff_workers
+        state_dict["worker_output"] = self._worker_output
+
+        # States related to interruption recovery.
         state_dict["current_kickoff_workers"] = self._current_kickoff_workers
         state_dict["input_buffer"] = self._input_buffer
-        # TODO: the data field of Event and Feedback must be serializable in order to serialize _ongoing_interactions
         state_dict["ongoing_interactions"] = self._ongoing_interactions
-        state_dict["worker_output"] = self._worker_output
+
         return state_dict
 
     @override
     def load_from_dict(self, state_dict: Dict[str, Any]) -> None:
         super().load_from_dict(state_dict)
-        # Deserialize from the state_dict
+
+        self.name = state_dict["name"]
+        self._automa_running = state_dict["automa_running"]
+        self._output_worker_key = state_dict["output_worker_key"]
+
+        # States related to workers.
         self._workers = state_dict["workers"]
         for worker in self._workers.values():
             worker.parent = self
-        self._automa_running = state_dict["automa_running"]
         self._worker_forwards = state_dict["worker_forwards"]
         self._workers_dynamic_states = state_dict["workers_dynamic_states"]
-        self._output_worker_key = state_dict["output_worker_key"]
+        self._worker_output = state_dict["worker_output"]
+
+        # States related to interruption recovery.
         self._current_kickoff_workers = state_dict["current_kickoff_workers"]
         self._input_buffer = state_dict["input_buffer"]
         self._ongoing_interactions = state_dict["ongoing_interactions"]
-        self._worker_output = state_dict["worker_output"]
+
+        ########
+        # The following states need not to be serialized but need to be initialized.
+        ########
+        # The list of the tasks that are currently being executed.
+        self._running_tasks = []
+        # deferred tasks
+        self._topology_change_deferred_tasks = []
+        self._set_output_worker_deferred_task = None
+        self._ferry_deferred_tasks = []
+        # event handling and human interactions
+        self._event_handlers = {}
+        self._default_event_handler = None
+        self._worker_interaction_indices = {}
+        self._thread_pool = None
 
     @classmethod
     def load_from_snapshot(

--- a/bridgic-core/bridgic/core/automa/worker/callable_worker.py
+++ b/bridgic-core/bridgic/core/automa/worker/callable_worker.py
@@ -112,6 +112,9 @@ class CallableWorker(Worker):
         else:
             self._callable = load_qualified_class_or_func(state_dict["callable_name"])
             self._expected_bound_parent = False
+        
+        # Cached method signatures, with no need for serialization.
+        self.__cached_param_names_of_callable = None
 
     @property
     def callable(self):

--- a/bridgic-core/bridgic/core/serialization/__init__.py
+++ b/bridgic-core/bridgic/core/serialization/__init__.py
@@ -1,3 +1,0 @@
-from .base import Serializable, Picklable
-
-__all__ = ["Serializable", "Picklable", "msgpackx"]

--- a/bridgic-core/bridgic/core/types/serialization.py
+++ b/bridgic-core/bridgic/core/types/serialization.py
@@ -1,10 +1,8 @@
 from typing import Protocol, TypeVar, runtime_checkable, Dict, Any
 from abc import abstractmethod
 
-T = TypeVar('T', covariant=True)
-
 @runtime_checkable
-class Serializable(Protocol[T]):
+class Serializable(Protocol):
     """
     Serializable is a protocol that defines the interface for objects that customizes serialization.
     The type parameter T is the type of the object to be serialized and deserialized, typically the subclass itself that implements Serializable.

--- a/bridgic-core/pyproject.toml
+++ b/bridgic-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bridgic-core"
-version = "0.1.0.dev6"
+version = "0.1.0.dev7"
 classifiers = [
     "Private :: Do Not Upload",
     "Programming Language :: Python :: 3",

--- a/bridgic-core/tests/core/automa/test_workers_serialization.py
+++ b/bridgic-core/tests/core/automa/test_workers_serialization.py
@@ -7,7 +7,7 @@ from typing import Optional, Dict, Any
 from typing_extensions import override
 from bridgic.core.automa import GraphAutoma, worker, ArgsMappingRule
 from bridgic.core.automa.worker import Worker, CallableWorker
-from bridgic.core.serialization import msgpackx
+from bridgic.core.utils import msgpackx
 from bridgic.core.types.error import WorkerRuntimeError
 
 ################## Test cases for Customized Worker ####################

--- a/bridgic-core/tests/core/serialization/test_serialization.py
+++ b/bridgic-core/tests/core/serialization/test_serialization.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Any, Set
 from typing_extensions import override
 import pytest
 from bridgic.core.automa.worker import Worker
-from bridgic.core.serialization import Serializable, Picklable
-import bridgic.core.serialization.msgpackx as msgpackx
+from bridgic.core.types.serialization import Serializable, Picklable
+from bridgic.core.utils import msgpackx
 from datetime import datetime, timezone, timedelta
 from pydantic import BaseModel
 

--- a/bridgic-core/uv.lock
+++ b/bridgic-core/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "bridgic-core"
-version = "0.1.0.dev6"
+version = "0.1.0.dev7"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },


### PR DESCRIPTION
The main refactoring and fixes included:
1. Reorganized GraphAutoma serialization/deserialization fields
2. Removed generics from Serializable
3. Recreated instances of msgpackx.dump_bytes using cls.__new__ (this removes the requirement that all deserializable types must have a no-argument constructor).
4. Added missing member fields during deserialization, such as running_options.
5. Added a Serializable base class to Worker and adjusted the metaclasses of Automa and GraphAutoma to resolve metaclass conflicts.
6. Adjusted serialization-related files and optimized some documentation.