### PR TITLE
Update package versions to 0.1.0.dev8 for bridgic-llms-openai and bri…

### DIFF
--- a/bridgic-integration/llms/bridgic-llms-openai-like/pyproject.toml
+++ b/bridgic-integration/llms/bridgic-llms-openai-like/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bridgic-llms-openai-like"
-version = "0.1.0.dev7"
+version = "0.1.0.dev8"
 classifiers = [
     "Private :: Do Not Upload",
     "Programming Language :: Python :: 3",

--- a/bridgic-integration/llms/bridgic-llms-openai-like/uv.lock
+++ b/bridgic-integration/llms/bridgic-llms-openai-like/uv.lock
@@ -206,7 +206,7 @@ dev = [
 
 [[package]]
 name = "bridgic-llms-openai-like"
-version = "0.1.0.dev7"
+version = "0.1.0.dev8"
 source = { editable = "." }
 dependencies = [
     { name = "bridgic-core" },

--- a/bridgic-integration/llms/bridgic-llms-openai/pyproject.toml
+++ b/bridgic-integration/llms/bridgic-llms-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bridgic-llms-openai"
-version = "0.1.0.dev7"
+version = "0.1.0.dev8"
 classifiers = [
     "Private :: Do Not Upload",
     "Programming Language :: Python :: 3",

--- a/bridgic-integration/llms/bridgic-llms-openai/uv.lock
+++ b/bridgic-integration/llms/bridgic-llms-openai/uv.lock
@@ -206,7 +206,7 @@ dev = [
 
 [[package]]
 name = "bridgic-llms-openai"
-version = "0.1.0.dev7"
+version = "0.1.0.dev8"
 source = { editable = "." }
 dependencies = [
     { name = "bridgic-core" },

--- a/bridgic-integration/llms/bridgic-llms-vllm/pyproject.toml
+++ b/bridgic-integration/llms/bridgic-llms-vllm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bridgic-llms-vllm"
-version = "0.1.0.dev4"
+version = "0.1.0.dev5"
 classifiers = [
     "Private :: Do Not Upload",
     "Programming Language :: Python :: 3",

--- a/bridgic-integration/llms/bridgic-llms-vllm/uv.lock
+++ b/bridgic-integration/llms/bridgic-llms-vllm/uv.lock
@@ -206,7 +206,7 @@ dev = [
 
 [[package]]
 name = "bridgic-llms-openai-like"
-version = "0.1.0.dev7"
+version = "0.1.0.dev8"
 source = { directory = "../bridgic-llms-openai-like" }
 dependencies = [
     { name = "bridgic-core" },
@@ -231,7 +231,7 @@ dev = [
 
 [[package]]
 name = "bridgic-llms-vllm"
-version = "0.1.0.dev4"
+version = "0.1.0.dev5"
 source = { editable = "." }
 dependencies = [
     { name = "bridgic-core" },


### PR DESCRIPTION
Update package versions to 0.1.0.dev8 for bridgic-llms-openai and bridgic-llms-openai-like, and to 0.1.0.dev5 for bridgic-llms-vllm, ensuring consistency across project dependencies.