### PR TITLE
Improve WorkerCallbackBuilder as generic support and update documentation

### DIFF
--- a/bridgic-core/bridgic/core/automa/worker/__init__.py
+++ b/bridgic-core/bridgic/core/automa/worker/__init__.py
@@ -1,19 +1,24 @@
 """
-The Worker module defines work nodes in Automa.
+The Worker module defines the Worker concept and its related implementations in Automa.
 
-This module contains the base classes of workers, which will be used within Automa.
-Workers are the basic execution units in Automa, with each work node typically 
-corresponding to a function (which can be synchronous or asynchronous) responsible 
-for executing specific business logic.
+This module provides the core abstractions and implementations of Worker, including:
+
+- **Worker**: The base class for all workers, which is the basic execution unit in Automa, 
+  defining the execution interface (`arun()` and `run()` methods) for nodes
+- **CallableWorker**: A worker implementation for wrapping callable objects (functions or methods)
+- **WorkerCallback**: A callback interface during worker execution, supporting validation, 
+  monitoring, and log collection before and after execution
+- **WorkerCallbackBuilder**: A builder for constructing and configuring worker callbacks
 """
 
 from ._worker import Worker
 from ._callable_worker import CallableWorker
-from ._worker_callback import WorkerCallback, WorkerCallbackBuilder
+from ._worker_callback import WorkerCallback, WorkerCallbackBuilder, T_WorkerCallback
 
 __all__ = [
     "Worker",
     "CallableWorker",
     "WorkerCallback",
     "WorkerCallbackBuilder",
+    "T_WorkerCallback",
 ]


### PR DESCRIPTION
- Make `WorkerCallbackBuilder` a generic class to support type inference
- Update `WorkerCallbackBuilder` documentation with detailed usage examples
- Export `T_WorkerCallback` type variable
- Improve Worker module docstring with clearer module description