### PR TITLE
refactor: check `is_top_level()` for arun() to avoid redundant task creation

### DIFF
--- a/bridgic-core/bridgic/core/automa/_graph_automa.py
+++ b/bridgic-core/bridgic/core/automa/_graph_automa.py
@@ -1083,9 +1083,39 @@ class GraphAutoma(Automa, metaclass=GraphMeta):
         """
         The entry point for running the constructed `GraphAutoma` instance.
 
-        For top-level automa, this method wraps the execution in a task to ensure
-        context isolation between multiple calls. For nested automa, it directly
-        calls `_arun_internal()` to avoid redundant task creation.
+        This method serves as the entry point for both initial execution and resumption after 
+        interruption of an automa instance. It automatically drives the execution of workers 
+        based on their `dependencies` and explicit `ferry_to()` calls. Each execution will be 
+        wrapped in an `asyncio.Task` to ensure context isolation.
+
+        **Automatic Scheduling**
+
+        The scheduling behavior in `GraphAutoma` is automatically driven by:
+
+        - Worker dependencies: Workers are scheduled to run only after all their necessary 
+          dependencies are satisfied. The dependencies automatically drive the execution order.
+
+        - Calling ferry_to: During execution, a worker can explicitly trigger another worker 
+          by calling `ferry_to()`, which enables dynamic flow control and conditional branching.
+
+        - Dynamic topology changes: When the graph topology is modified at runtime (such as 
+          adding or removing workers or dependencies), the scheduling system seamlessly updates 
+          to reflect the latest structure, ensuring that worker execution always follows the 
+          current graph.
+
+        **Human Interaction Mechanism**
+
+        Workers can request human input by calling `interact_with_human()` during execution. 
+        When this occurs:
+
+        - The execution will be paused after the running workers finish their execution.
+        - The Automa's state will be serialized into a `Snapshot` object.
+        - An `InteractionException` will be raised to the application layer. It contains both the 
+          list of pending `Interaction` objects and the `Snapshot` object.
+        - The application layer may persist the `Snapshot` properly to resume the execution later.
+        - To resume execution, the application layer should reload the Automa state using 
+          `load_from_snapshot()` with the saved `Snapshot` object and call `arun()` again with 
+          `feedback_data` containing the user's feedback(s) to finish a complete interactions.
 
         Parameters
         ----------


### PR DESCRIPTION
Modify `_arun_internal` implementation with top-level check to avoid redundant task creation when automa is nested