### PR TITLE
feat: Add running_options parameter to all Automa subclasses and implement serialization for WorkerCallbackBuilder

### DIFF
--- a/bridgic-core/bridgic/core/agentic/_concurrent_automa.py
+++ b/bridgic-core/bridgic/core/agentic/_concurrent_automa.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import List, Any, Callable, Final, cast, Tuple, Dict, Union
 from typing_extensions import override
 
-from bridgic.core.automa import GraphAutoma
+from bridgic.core.automa import GraphAutoma, RunningOptions
 from bridgic.core.automa.worker import Worker
 from bridgic.core.types._error import AutomaRuntimeError
 from bridgic.core.types._common import AutomaType, ArgsMappingRule
@@ -37,8 +37,9 @@ class ConcurrentAutoma(GraphAutoma):
         self,
         name: Optional[str] = None,
         thread_pool: Optional[ThreadPoolExecutor] = None,
+        running_options: Optional[RunningOptions] = None,
     ):
-        super().__init__(name=name, thread_pool=thread_pool)
+        super().__init__(name=name, thread_pool=thread_pool, running_options=running_options)
 
         # Implementation notes:
         # There are two types of workers in the concurrent automa:

--- a/bridgic-core/bridgic/core/agentic/_sequential_automa.py
+++ b/bridgic-core/bridgic/core/agentic/_sequential_automa.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing_extensions import override
 
 from bridgic.core.automa.worker import Worker
-from bridgic.core.automa import GraphAutoma
+from bridgic.core.automa import GraphAutoma, RunningOptions
 from bridgic.core.types._error import AutomaRuntimeError
 from bridgic.core.types._common import AutomaType, ArgsMappingRule
 
@@ -32,8 +32,9 @@ class SequentialAutoma(GraphAutoma):
         self,
         name: Optional[str] = None,
         thread_pool: Optional[ThreadPoolExecutor] = None,
+        running_options: Optional[RunningOptions] = None,
     ):
-        super().__init__(name=name, thread_pool=thread_pool)
+        super().__init__(name=name, thread_pool=thread_pool, running_options=running_options)
 
         cls = type(self)
         self._last_worker_key = None

--- a/bridgic-core/bridgic/core/agentic/react/_react_automa.py
+++ b/bridgic-core/bridgic/core/agentic/react/_react_automa.py
@@ -5,7 +5,7 @@ from typing_extensions import override
 from concurrent.futures import ThreadPoolExecutor
 from jinja2 import Environment, PackageLoader, Template
 
-from bridgic.core.automa import Automa, GraphAutoma, worker
+from bridgic.core.automa import Automa, GraphAutoma, worker, RunningOptions
 from bridgic.core.automa.args import From, ArgsMappingRule, System
 from bridgic.core.model.protocols import ToolSelection
 from bridgic.core.model.types import Tool, ToolCall
@@ -45,10 +45,11 @@ class ReActAutoma(GraphAutoma):
         tools: Optional[List[Union[Callable, Automa, ToolSpec]]] = None,
         name: Optional[str] = None,
         thread_pool: Optional[ThreadPoolExecutor] = None,
+        running_options: Optional[RunningOptions] = None,
         max_iterations: int = DEFAULT_MAX_ITERATIONS,
         prompt_template: str = DEFAULT_TEMPLATE_FILE,
     ):
-        super().__init__(name=name, thread_pool=thread_pool)
+        super().__init__(name=name, thread_pool=thread_pool, running_options=running_options)
 
         self._llm = llm
         if system_prompt:


### PR DESCRIPTION
feat: Add running_options parameter to all Automa subclasses and implement serialization for WorkerCallbackBuilder

- Add running_options parameter to ConcurrentAutoma, SequentialAutoma, and ReActAutoma
- Implement serialization/deserialization support for WorkerCallbackBuilder to ensure Automa instances can properly handle callback_builders during serialization/deserialization