### PR TITLE
Update observability documentation for LangWatch and Opik integrations

### DIFF
--- a/docs/docs/tutorials/items/observability/lang_watch_integration.md
+++ b/docs/docs/tutorials/items/observability/lang_watch_integration.md
@@ -186,19 +186,3 @@ Once your Bridgic application has finished running, traces will be automatically
 <div style="text-align: center;">
 <img src="../../../imgs/bridgic-integration-langwatch-demo.png" alt="bridgic integration langwatch demo" width="auto">
 </div>
-
-## Parameters
-
-The `start_langwatch_trace` function accept the following parameters:
-
-- `api_key` (Optional[str]): The API key for the LangWatch tracing service. If `None`, the `LANGWATCH_API_KEY` environment variable will be used.
-- `endpoint_url` (Optional[str]): The URL of the LangWatch tracing service. If `None`, the `LANGWATCH_ENDPOINT` environment variable will be used. If that is also not provided, the default value will be `https://app.langwatch.ai`.
-- `base_attributes` (Optional[BaseAttributes]): The base attributes to use for the LangWatch tracing client. These attributes will be included in all traces and spans.
-
-## Features
-
-- **Worker-level tracing**: Each worker execution is traced as a separate LangWatch span
-- **Nested automa support**: Properly handles nested automa instances with hierarchical tracing
-- **Error tracking**: Captures and reports errors during worker execution
-- **Execution metadata**: Tracks execution duration, start/end times, and other metadata
-- **Concurrent execution**: Supports tracing multiple concurrent automa executions

--- a/docs/docs/tutorials/items/observability/opik_integration.md
+++ b/docs/docs/tutorials/items/observability/opik_integration.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-[Comet Opik](https://www.comet.com/docs/opik/) is a comprehensive observability platform designed for agentic systems. The `bridgic-callbacks-trace-opik` package enables seamless integration of Opik into your Bridgic-based agentic workflows.
+[Comet Opik](https://www.comet.com/docs/opik/) is a comprehensive observability platform designed for agentic systems. The `bridgic-traces-opik` package enables seamless integration of Opik into your Bridgic-based agentic workflows.
 
 This integration is primarily supported by `OpikTraceCallback`, a [WorkerCallback](../core_mechanism/worker_callback.ipynb) implementation that automatically instruments the worker execution with Opik tracing, which provides comprehensive observability by:
 
@@ -177,7 +177,7 @@ class DataAnalysisAutoma(GraphAutoma):
         return f"Report: Found {len(analysis['trends'])} trends with {analysis['confidence']} confidence."
 
 async def automa_arun():
-    builder = WorkerCallbackBuilder(OpikTraceCallback, init_kwargs={"project_name": "bridgic-demo"})
+    builder = WorkerCallbackBuilder(OpikTraceCallback, init_kwargs={"project_name": "bridgic-integration-demo"})
     running_options = RunningOptions(callback_builders=[builder])
     automa = DataAnalysisAutoma(running_options=running_options)
     result = await automa.arun(topic="market analysis")


### PR DESCRIPTION
- Removed outdated parameters section from LangWatch integration documentation.
- Updated package name in Opik integration documentation for consistency.
- Adjusted project name in example code for Opik integration.