### PR TITLE
feat: add version attribute to LangWatch and Opik trace modules

### DIFF
--- a/bridgic-integration/traces/bridgic-traces-langwatch/bridgic/traces/langwatch/__init__.py
+++ b/bridgic-integration/traces/bridgic-traces-langwatch/bridgic/traces/langwatch/__init__.py
@@ -1,5 +1,6 @@
+from importlib.metadata import version
 from ._langwatch_trace_callback import LangWatchTraceCallback
 from ._utils import start_langwatch_trace
 
-__all__ = ["LangWatchTraceCallback", "start_langwatch_trace"]
-
+__version__ = version("bridgic-traces-langwatch")
+__all__ = ["LangWatchTraceCallback", "start_langwatch_trace", "__version__"]

--- a/bridgic-integration/traces/bridgic-traces-opik/bridgic/traces/opik/__init__.py
+++ b/bridgic-integration/traces/bridgic-traces-opik/bridgic/traces/opik/__init__.py
@@ -1,4 +1,6 @@
+from importlib.metadata import version
 from ._opik_trace_callback import OpikTraceCallback
 from ._utils import start_opik_trace
 
-__all__ = ["OpikTraceCallback", "start_opik_trace"]
+__version__ = version("bridgic-traces-opik")
+__all__ = ["OpikTraceCallback", "start_opik_trace", "__version__"]


### PR DESCRIPTION
- Introduced `__version__` attribute in both `bridgic-traces-langwatch` and `bridgic-traces-opik` modules to provide version information.