### PR TITLE
Feature/inputs propagation adjust

### DIFF
--- a/bridgic-core/bridgic/core/automa/args/_args_binding.py
+++ b/bridgic-core/bridgic/core/automa/args/_args_binding.py
@@ -381,12 +381,18 @@ class ArgsManager:
             
         positional_only_param_names = get_param_names(rx_param_names_dict.get(Parameter.POSITIONAL_ONLY, []))
         positional_or_keyword_param_names = get_param_names(rx_param_names_dict.get(Parameter.POSITIONAL_OR_KEYWORD, []))
+        var_keyword_param_names = get_param_names(rx_param_names_dict.get(Parameter.VAR_KEYWORD, []))
 
         propagation_kwargs = {}
         for key, value in input_kwargs.items():
-            if key in positional_only_param_names:
+            if var_keyword_param_names:
                 propagation_kwargs[key] = value
-            elif key in positional_or_keyword_param_names:
+                continue
+
+            if (
+                key in positional_only_param_names or
+                key in positional_or_keyword_param_names
+            ):
                 propagation_kwargs[key] = value
 
         return (), propagation_kwargs


### PR DESCRIPTION
adjust inputs propagation include `kwargs`. For example:

```python
class MyGraph(GraphAutoma):
    @worker(is_start=True)
    async def worker_1(user_input: int):
        return user_input + 1
        
    @worker(dependencies=["worker_1"], is_output=True)
    async def worker_2(x: int, **kwargs):
        user_input = kwargs["user_input"]
        print(user_input)
        return x + 1
        
 g = MyGraph()
 g.arun(user_input=1)
```
At this point, because worker_2 wrote the `**kwargs` parameter, the user_input parameter will still be broadcast to its parameter list.
