### PR TITLE
feat: unify the generation of the `id` field of `ToolCall`.

### DIFF
--- a/packages/bridgic-core/bridgic/core/utils/_uuid.py
+++ b/packages/bridgic-core/bridgic/core/utils/_uuid.py
@@ -1,0 +1,7 @@
+import uuid
+
+def generate_tool_id() -> str:
+    """
+    Generate a unique tool ID and make sure its length is no more than 30 characters.
+    """
+    return f"tool_{uuid.uuid4().hex[:25]}"

--- a/packages/bridgic-integration/llms/bridgic-llms-openai/bridgic/llms/openai/_openai_llm.py
+++ b/packages/bridgic-integration/llms/bridgic-llms-openai/bridgic/llms/openai/_openai_llm.py
@@ -20,6 +20,7 @@ from bridgic.core.model.types import *
 from bridgic.core.model.protocols import StructuredOutput, ToolSelection, PydanticModel, JsonSchema, Constraint
 from bridgic.core.utils._console import printer
 from bridgic.core.utils._collection import filter_dict, merge_dict, validate_required_params
+from bridgic.core.utils._uuid import generate_tool_id
 from bridgic.llms.openai_like import OpenAILikeConfiguration
 
 class OpenAIConfiguration(OpenAILikeConfiguration):
@@ -1077,7 +1078,7 @@ class OpenAILlm(BaseLlm, StructuredOutput, ToolSelection):
     def _convert_tool_calls(self, tool_calls: List[ChatCompletionMessageFunctionToolCall]) -> List[ToolCall]:
         return [] if tool_calls is None else [
             ToolCall(
-                id=tool_call.id,
+                id=generate_tool_id(),
                 name=tool_call.function.name,
                 arguments=json.loads(tool_call.function.arguments),
             ) for tool_call in tool_calls

--- a/packages/bridgic-integration/llms/bridgic-llms-openai/pyproject.toml
+++ b/packages/bridgic-integration/llms/bridgic-llms-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bridgic-llms-openai"
-version = "0.1.1"
+version = "0.1.2.dev1"
 license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/packages/bridgic-integration/llms/bridgic-llms-vllm/bridgic/llms/vllm/_vllm_server_llm.py
+++ b/packages/bridgic-integration/llms/bridgic-llms-vllm/bridgic/llms/vllm/_vllm_server_llm.py
@@ -12,6 +12,7 @@ from bridgic.core.model.protocols import StructuredOutput, ToolSelection, Pydant
 from bridgic.llms.openai_like import OpenAILikeLlm, OpenAILikeConfiguration
 from bridgic.core.utils._console import printer
 from bridgic.core.utils._collection import validate_required_params, merge_dict, filter_dict
+from bridgic.core.utils._uuid import generate_tool_id
 
 class VllmServerConfiguration(OpenAILikeConfiguration):
     """
@@ -471,7 +472,7 @@ class VllmServerLlm(OpenAILikeLlm, StructuredOutput, ToolSelection):
     def _convert_tool_calls(self, tool_calls: List[ChatCompletionMessageFunctionToolCall]) -> List[ToolCall]:
         return [
             ToolCall(
-                id=tool_call.id,
+                id=generate_tool_id(),
                 name=tool_call.function.name,
                 arguments=json.loads(tool_call.function.arguments),
             ) for tool_call in tool_calls

--- a/packages/bridgic-integration/llms/bridgic-llms-vllm/pyproject.toml
+++ b/packages/bridgic-integration/llms/bridgic-llms-vllm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bridgic-llms-vllm"
-version = "0.1.1"
+version = "0.1.2.dev1"
 license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
To make sure that their length from different llm providers are the same.