### PR TITLE
Docs/fix script (#180)

### DIFF
--- a/docs/docs/tutorials/items/quick_start/quick_start.ipynb
+++ b/docs/docs/tutorials/items/quick_start/quick_start.ipynb
@@ -7,9 +7,7 @@
    "source": [
     "# Quick Start\n",
     "\n",
-    "In this tutorial, we assume that Bridgic is already installed on your system. If that’s not the case, see [Installation](../../../installation).\n",
-    "\n",
-    "Let's start by building a simple word learning assistant. You provide a word, and the assistant will generate its derived forms and create sentences with them. This example will also show how to use Bridgic in practice.\n",
+    "In this tutorial, we assume that Bridgic is already installed on your system. Let's begin by creating a simple word learning assistant. You just need to provide a word, and the assistant will automatically generate its derived forms and craft example sentences using them. This example will also give you hands-on experience with how Bridgic works in practice.\n",
     "\n",
     "## Word learning assistant\n",
     "\n",

--- a/docs/scripts/doc_config.yaml
+++ b/docs/scripts/doc_config.yaml
@@ -79,6 +79,9 @@ generation_options:
   only_index_pages: true
   # Render single-entry packages as groups with Index child in nav (ensures visibility)
   single_entry_as_group: true
+  # Module identifiers for which index.md should NOT be generated (e.g. bridgic.core)
+  exclude_index_modules:
+    - "bridgic.core"
   
   # Docstring style (numpy, google, sphinx)
   docstring_style: "numpy"

--- a/docs/scripts/gen_mkdocs_yml.py
+++ b/docs/scripts/gen_mkdocs_yml.py
@@ -66,6 +66,8 @@ class DocumentationConfig:
             "conftest.py",
             "version.py"
         }
+        # Module identifiers (e.g. "bridgic.core") for which index.md should NOT be generated
+        self.exclude_index_modules = set()
         
         # Package directories to process
         self.packages = ["bridgic-core", "bridgic-asl"]
@@ -135,6 +137,8 @@ class DocumentationConfig:
                 self.docstring_style = gen_opts.get('docstring_style', self.docstring_style)
                 self.only_index_pages = gen_opts.get('only_index_pages', self.only_index_pages)
                 self.single_entry_as_group = gen_opts.get('single_entry_as_group', self.single_entry_as_group)
+                if 'exclude_index_modules' in gen_opts:
+                    self.exclude_index_modules = set(gen_opts['exclude_index_modules'])
             
             # mkdocstrings_options now governed by mkdocs_template.yml; ignore here
                     
@@ -688,6 +692,12 @@ class DocumentationGenerator:
                         if self.config.verbose:
                             logger.debug(f"Skipping {path} - no __all__ defined")
                         continue
+                    # Skip index pages for modules in exclude_index_modules (e.g. bridgic.core)
+                    identifier = self.generate_module_identifier(parts)
+                    if identifier in self.config.exclude_index_modules:
+                        if self.config.verbose:
+                            logger.debug(f"Skipping index for excluded module: {identifier}")
+                        continue
                 elif parts[-1] == "__main__":
                     continue
                 elif self.config.only_index_pages:
@@ -847,6 +857,12 @@ class DocumentationGenerator:
                     if not has_all:
                         if self.config.verbose:
                             logger.debug(f"Skipping {path} - no __all__ defined")
+                        continue
+                    # Skip nav/node for modules listed in exclude_index_modules (e.g. bridgic.core)
+                    identifier = self.generate_module_identifier(parts)
+                    if identifier in self.config.exclude_index_modules:
+                        if self.config.verbose:
+                            logger.debug(f"Skipping nav for excluded index module: {identifier}")
                         continue
                 elif parts[-1] == "__main__":
                     continue


### PR DESCRIPTION
* Enhance documentation configuration to exclude specific modules from index generation. Added 'exclude_index_modules' option in doc_config.yaml and updated gen_mkdocs_yml.py to handle this new setting.

* docs: update quick start.