### PR TITLE
fix: harden amphibious template hooks & realign skills with new scaffold

### DIFF
--- a/.github/workflows/skill-install-deps-check.yml
+++ b/.github/workflows/skill-install-deps-check.yml
@@ -1,0 +1,223 @@
+name: Skill Install-Deps Check
+
+# Validates that every skill's install-deps.sh can successfully bootstrap a
+# fresh project environment from its deps*.ini config. Gates PRs targeting
+# main so broken skill installers can't land on the release line.
+#
+# Matrix is discovered dynamically by scanning skills/*/scripts/deps*.ini —
+# adding a new skill or provider config requires no workflow change.
+#
+# Filename convention:
+#   deps.ini              → single-config skill (no provider arg)
+#   deps.<provider>.ini   → multi-provider skill, passes <provider> as arg 2
+#
+# Main-branch policy: every [package] in deps.ini MUST declare
+# `source = "default"` (public PyPI). Private-index references are a dev-only
+# convenience and are rejected here — they have no business on main.
+# install-deps.sh itself still supports private indexes via BRIDGIC_DEV_INDEX
+# for local/dev flows; this workflow just refuses to let them ship.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'skills/**'
+      - '.github/workflows/skill-install-deps-check.yml'
+  workflow_dispatch:
+
+jobs:
+  discover:
+    name: Discover skill configs
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+      count: ${{ steps.build.outputs.count }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build matrix from skills/*/scripts/deps*.ini
+        id: build
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          entries=()
+          for script in skills/*/scripts/install-deps.sh; do
+            skill_dir="$(dirname "$(dirname "$script")")"
+            skill_name="$(basename "$skill_dir")"
+            script_dir="$(dirname "$script")"
+
+            configs=("$script_dir"/deps*.ini)
+            if [ ${#configs[@]} -eq 0 ]; then
+              echo "::warning::skill '$skill_name' has install-deps.sh but no deps*.ini — skipped"
+              continue
+            fi
+
+            for cfg in "${configs[@]}"; do
+              cfg_name="$(basename "$cfg")"
+              if [ "$cfg_name" = "deps.ini" ]; then
+                provider=""
+              else
+                # strip leading "deps." and trailing ".ini"
+                provider="${cfg_name#deps.}"
+                provider="${provider%.ini}"
+              fi
+              entries+=("{\"skill\":\"$skill_name\",\"provider\":\"$provider\",\"config\":\"$cfg_name\"}")
+            done
+          done
+
+          count=${#entries[@]}
+          if [ "$count" -eq 0 ]; then
+            echo "::warning::no skill deps configs discovered"
+            matrix='{"include":[]}'
+          else
+            joined="$(IFS=,; echo "${entries[*]}")"
+            matrix="{\"include\":[${joined}]}"
+          fi
+
+          echo "Discovered $count config(s):"
+          printf '  %s\n' "${entries[@]}"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "count=$count"   >> "$GITHUB_OUTPUT"
+
+  validate:
+    name: Validate ${{ matrix.skill }} / ${{ matrix.config }}
+    needs: discover
+    if: ${{ needs.discover.outputs.count != '0' }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Enforce main-branch policy — deps.ini must be public-PyPI only
+        env:
+          SKILL: ${{ matrix.skill }}
+          CONFIG: ${{ matrix.config }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cfg="$GITHUB_WORKSPACE/skills/${SKILL}/scripts/${CONFIG}"
+          # Emit one line per non-default source declaration: <section> -> <value>
+          violations="$(awk '
+            function trim(s) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", s); return s }
+            /^[[:space:]]*[#;]/ { next }
+            /^[[:space:]]*$/    { next }
+            /^[[:space:]]*\[.*\][[:space:]]*$/ {
+              line = $0
+              sub(/^[[:space:]]*\[/, "", line); sub(/\][[:space:]]*$/, "", line)
+              section = trim(line); next
+            }
+            /^[[:space:]]*source[[:space:]]*=/ {
+              eq = index($0, "=")
+              val = trim(substr($0, eq + 1))
+              sub(/^"/, "", val); sub(/"$/, "", val)
+              if (val != "default") print section " -> " val
+            }
+          ' "$cfg")"
+          if [ -n "$violations" ]; then
+            echo "::error::$CONFIG declares non-default (private-index) sources — not allowed on main:"
+            echo "$violations" | sed 's/^/  /'
+            echo ""
+            echo "Switch every package to source = \"default\" (public PyPI) before merging to main."
+            exit 1
+          fi
+          echo "OK: $CONFIG references public PyPI only"
+
+      - name: Run install-deps.sh in scratch project dir
+        env:
+          SKILL: ${{ matrix.skill }}
+          PROVIDER: ${{ matrix.provider }}
+          CONFIG: ${{ matrix.config }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          script="$GITHUB_WORKSPACE/skills/${SKILL}/scripts/install-deps.sh"
+          if [ ! -x "$script" ] && [ ! -f "$script" ]; then
+            echo "::error::install-deps.sh not found at $script"
+            exit 1
+          fi
+
+          scratch="$(mktemp -d -t bridgic-skill-check.XXXXXX)"
+          echo "Skill:       $SKILL"
+          echo "Config:      $CONFIG"
+          echo "Provider:    ${PROVIDER:-<none>}"
+          echo "Scratch dir: $scratch"
+          echo "Script:      $script"
+          echo ""
+
+          log="$(mktemp)"
+          set +e
+          if [ -n "$PROVIDER" ]; then
+            bash "$script" "$scratch" "$PROVIDER" 2>&1 | tee "$log"
+          else
+            bash "$script" "$scratch" 2>&1 | tee "$log"
+          fi
+          status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$status" -ne 0 ]; then
+            echo "::error::install-deps.sh exited with status $status for $SKILL / $CONFIG"
+            exit "$status"
+          fi
+
+          # Belt-and-suspenders: script uses `set -e` + structured fail marker,
+          # but also assert the success marker made it to stdout so a future
+          # silent-success regression can't sneak past.
+          if ! grep -qE '^=== DEPS_READY' "$log"; then
+            echo "::error::DEPS_READY marker missing from install-deps.sh output"
+            exit 1
+          fi
+
+          echo ""
+          echo "OK: $SKILL / $CONFIG bootstrapped cleanly"
+
+  summary:
+    name: Check Summary
+    needs: [discover, validate]
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - name: Aggregate results
+        run: |
+          discover_result="${{ needs.discover.result }}"
+          validate_result="${{ needs.validate.result }}"
+          count="${{ needs.discover.outputs.count }}"
+
+          echo "discover: $discover_result"
+          echo "validate: $validate_result"
+          echo "configs discovered: $count"
+
+          if [ "$discover_result" != "success" ]; then
+            echo "::error::discover job did not succeed"
+            exit 1
+          fi
+
+          if [ "$count" = "0" ]; then
+            echo "No skill configs to validate — treating as pass"
+            exit 0
+          fi
+
+          if [ "$validate_result" != "success" ]; then
+            echo "::error::one or more skill install-deps checks failed"
+            exit 1
+          fi
+
+          echo "All skill install-deps checks passed"

--- a/packages/bridgic-amphibious/bridgic/amphibious/_amphibious_automa.py
+++ b/packages/bridgic-amphibious/bridgic/amphibious/_amphibious_automa.py
@@ -648,8 +648,13 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
         """
         Agent-level before_action hook, shared across all workers.
 
-        Called when a worker's ``before_action()`` returns ``_DELEGATE``.
-        Override to intercept and modify tool calls at the agent level.
+        Called when a worker's ``before_action()`` returns ``_DELEGATE``
+        (or ``None``, which is treated identically). Override to intercept
+        and modify tool calls at the agent level.
+
+        Returning ``None`` from this hook is treated as a passthrough — the
+        original ``decision_result`` is preserved — so that stub overrides
+        do not silently drop the decision.
 
         Parameters
         ----------
@@ -1366,14 +1371,23 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
         ########################
         # Execution of the action based on the decision result
         ########################
-        # before_action delegation: worker → agent (if _DELEGATE)
+        # before_action delegation: worker → agent.
+        # ``None`` is treated as "no-op override" so that AI-generated stubs
+        # (``async def before_action(...): pass``) behave identically to not
+        # overriding the hook at all:
+        #   - worker-level None ≡ _DELEGATE → fall through to agent-level
+        #   - agent-level None  ≡ passthrough → keep original decision_result
         original_decision_result = decision_result
         if _worker is not None:
-            decision_result = await _worker.before_action(decision_result, ctx)
-            if decision_result is _DELEGATE:
-                decision_result = await self.before_action(original_decision_result, ctx)
+            worker_ret = await _worker.before_action(decision_result, ctx)
+            if worker_ret is _DELEGATE or worker_ret is None:
+                agent_ret = await self.before_action(original_decision_result, ctx)
+                decision_result = original_decision_result if agent_ret is None else agent_ret
+            else:
+                decision_result = worker_ret
         else:
-            decision_result = await self.before_action(decision_result, ctx)
+            agent_ret = await self.before_action(decision_result, ctx)
+            decision_result = original_decision_result if agent_ret is None else agent_ret
 
         # Execute the action based on the (possibly delegated) decision result
         result = None
@@ -1398,10 +1412,12 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
             result = Step(content=decision.step_content, result=action_result, metadata={})
             ctx.add_info(result)
 
-        # after_action delegation: worker → agent (if _DELEGATE)
+        # after_action delegation: worker → agent.
+        # Worker-level ``None`` ≡ ``_DELEGATE`` so AI-generated ``pass`` stubs
+        # still chain to the agent-level hook.
         if _worker is not None:
             delegate = await _worker.after_action(result, ctx)
-            if delegate is _DELEGATE:
+            if delegate is _DELEGATE or delegate is None:
                 await self.after_action(result, ctx)
         else:
             await self.after_action(result, ctx)
@@ -1499,8 +1515,17 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
         })
 
     def _has_workflow(self) -> bool:
-        """Check whether the subclass has overridden on_workflow()."""
-        return type(self).on_workflow is not AmphibiousAutoma.on_workflow
+        """Check whether the subclass has overridden on_workflow() with a real async generator.
+
+        A subclass that writes ``async def on_workflow(...): pass`` (e.g. an
+        AI-generated stub) produces a coroutine, not an async generator —
+        treat that as "not overridden" so RunMode resolution falls back to
+        the agent path instead of crashing on generator-protocol calls.
+        """
+        impl = type(self).on_workflow
+        if impl is AmphibiousAutoma.on_workflow:
+            return False
+        return inspect.isasyncgenfunction(impl)
 
     def _has_agent(self) -> bool:
         """Check whether the subclass has overridden on_agent()."""

--- a/packages/bridgic-amphibious/bridgic/amphibious/_amphibious_automa.py
+++ b/packages/bridgic-amphibious/bridgic/amphibious/_amphibious_automa.py
@@ -743,6 +743,10 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
         -------
         Any
             The (optionally processed) result to store in execution history.
+
+            Returning ``None`` (e.g. an empty ``pass`` override) is treated
+            as passthrough — the original ``decision_result`` is preserved
+            so that stub overrides do not silently drop the typed output.
         """
         return decision_result
 
@@ -867,8 +871,11 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
             worker_name = worker.__class__.__name__
 
             # 1. Observe
+            # Worker-level ``None`` (e.g. an AI-generated ``pass`` stub) is
+            # treated identically to ``_DELEGATE`` so the agent-level
+            # observation fallback still runs.
             obs = await worker.observation(context)
-            if obs is _DELEGATE:
+            if obs is _DELEGATE or obs is None:
                 obs = await self.observation(context)
             context.observation = obs
 
@@ -1131,9 +1138,11 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
                 decision = item.decision
 
                 # 1. Observe
+                # Worker-level ``None`` ≡ ``_DELEGATE`` so AI-generated stubs
+                # still fall through to the agent-level observation hook.
                 if worker is not None:
                     obs = await worker.observation(ctx)
-                    if obs is _DELEGATE:
+                    if obs is _DELEGATE or obs is None:
                         obs = await self.observation(ctx)
                 else:
                     obs = await self.observation(ctx)
@@ -1408,7 +1417,11 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
                 )
                 ctx.add_info(result)
         else:
-            action_result = await self.action_custom_output(decision_result, ctx)
+            # ``None`` (e.g. from an AI-generated ``pass`` stub) is treated as
+            # passthrough so the typed output is preserved instead of being
+            # silently dropped.
+            custom_ret = await self.action_custom_output(decision_result, ctx)
+            action_result = decision_result if custom_ret is None else custom_ret
             result = Step(content=decision.step_content, result=action_result, metadata={})
             ctx.add_info(result)
 

--- a/packages/bridgic-amphibious/bridgic/amphibious/_amphibious_automa.py
+++ b/packages/bridgic-amphibious/bridgic/amphibious/_amphibious_automa.py
@@ -1081,6 +1081,25 @@ class AmphibiousAutoma(GraphAutoma, Generic[CognitiveContextT]):
                     send_value = None  # Reset for next iteration
                 except StopAsyncIteration:
                     break
+                except Exception as e:
+                    # Generator-internal code (helper / inline logic between yields) raised.
+                    # The generator object is now dead and cannot be resumed via asend(),
+                    # so step-level fallback is impossible — only full fallback or re-raise.
+                    if not will_fallback:
+                        raise
+                    if not self._has_agent():
+                        raise RuntimeError(
+                            f"Workflow generator raised at step {step_index}: {e}\n"
+                            f"on_agent() is not overridden, cannot fall back."
+                        ) from e
+                    self._log(
+                        "Workflow",
+                        f"[ERROR] Generator code raised at step {step_index}: {e} — "
+                        f"falling back to on_agent().",
+                        color="red",
+                    )
+                    await self.on_agent(ctx)
+                    return
                 
                 # When returning an AgentCall proactively in on_workflow, it is by default assumed that a brand new and clean
                 # context is initiated for a new goal target to execute the agent mode. Otherwise, you can customize the

--- a/packages/bridgic-amphibious/bridgic/amphibious/_cognitive_worker.py
+++ b/packages/bridgic-amphibious/bridgic/amphibious/_cognitive_worker.py
@@ -791,6 +791,10 @@ class CognitiveWorker(GraphAutoma):
         ``before_action()`` method. Override to intercept and modify tool calls
         at the worker level.
 
+        Returning ``None`` (e.g. an empty ``pass`` override) is treated
+        identically to ``_DELEGATE`` so that stub overrides do not break the
+        delegation chain.
+
         Parameters
         ----------
         decision_result : Any
@@ -821,7 +825,9 @@ class CognitiveWorker(GraphAutoma):
         context fields or perform side effects at the worker level.
 
         The return value is a *control signal*, not a data channel:
-        - Return ``_DELEGATE`` to also invoke the agent-level ``after_action``.
+        - Return ``_DELEGATE`` (or ``None``) to also invoke the agent-level
+          ``after_action``. Treating ``None`` as ``_DELEGATE`` keeps stub
+          overrides (``async def after_action(...): pass``) safe.
         - Return anything else to suppress the agent-level hook.
         The returned value itself is discarded — the step_result stored in
         history is never replaced by this hook. Perform any mutation by

--- a/packages/bridgic-amphibious/bridgic/amphibious/_cognitive_worker.py
+++ b/packages/bridgic-amphibious/bridgic/amphibious/_cognitive_worker.py
@@ -694,6 +694,10 @@ class CognitiveWorker(GraphAutoma):
             _DELEGATE to delegate observation to AmphibiousAutoma.observation().
             A string to use as the observation directly.
 
+            Returning ``None`` (e.g. an empty ``pass`` override) is treated
+            identically to ``_DELEGATE`` so that stub overrides do not
+            bypass the agent-level fallback.
+
         Examples
         --------
         >>> async def observation(self, context):

--- a/packages/bridgic-amphibious/bridgic/amphibious/scaffold.py
+++ b/packages/bridgic-amphibious/bridgic/amphibious/scaffold.py
@@ -1,29 +1,22 @@
 """
 Project scaffolding for Amphibious Automa projects.
 
-Creates the standard directory structure for an amphibious automa project:
-
-    <project_name>/
-    ├── task.md                # Task description (input)
-    ├── config.py              # LLM configuration
-    ├── tools.py               # Tool definitions
-    ├── workers.py             # Context, data models, custom workers
-    ├── agents.py              # Amphibious agent code
-    ├── skills/                # Amphibious skills (SKILL.md files)
-    ├── result/                # Trace and analysis results
-    └── log/                   # Runtime logs
+Generates a single ``amphi.py`` file in the target directory (default: cwd)
+containing a stub :class:`AmphibiousAutoma` subclass. Runtime concerns
+(LLM credentials, entry-point script, etc.) are intentionally left to the
+caller — the scaffold only seeds the agent definition.
 
 Usage
 -----
 CLI::
 
-    bridgic-amphibious create -n my_project
-    bridgic-amphibious create -n my_project --task "Navigate to example.com and extract data"
+    bridgic-amphibious create
+    bridgic-amphibious create --task "Navigate to example.com and extract data"
 
 Python API::
 
     from bridgic.amphibious.scaffold import create_project
-    create_project("my_project", task="Navigate to example.com and extract data")
+    create_project(task="Navigate to example.com and extract data")
 """
 
 from __future__ import annotations
@@ -34,149 +27,93 @@ from pathlib import Path
 from typing import Optional
 
 
-# ──────────────────────────────────────────────────────────────────────
-# Templates
-# ──────────────────────────────────────────────────────────────────────
+_AMPHI_FILENAME = "amphi.py"
 
-_TASK_MD = """\
-# Task Description
-
-{task}
-"""
-
-_CONFIG_PY = '''\
-"""LLM configuration for this project."""
-
-import os
-from dotenv import load_dotenv
-
-load_dotenv()  # Load environment variables from .env file if present
-
-LLM_API_BASE = os.getenv("LLM_API_BASE", "")
-LLM_API_KEY = os.getenv("LLM_API_KEY", "")
-LLM_MODEL = os.getenv("LLM_MODEL", "")
-'''
-
-_TOOLS_PY = '''\
-"""Tool definitions for this project.
-
-Define your tools here and export them for use in agents.py.
-"""
-
-import os
-
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-'''
-
-_WORKERS_PY = '''\
-"""Context, data models, and custom workers for this project.
-
-Define your custom CognitiveContext subclass, data models, and any
-CognitiveWorker subclasses here.
-"""
-
-from typing import Optional
-
-from pydantic import Field
-
-from bridgic.amphibious import CognitiveContext
+_AMPHI_PY = '''\
+{task_comment}from bridgic.amphibious import (
+    AmphibiousAutoma,
+    CognitiveContext,
+    CognitiveWorker,
+    think_unit,
+    ActionCall,
+    AgentCall,
+    HumanCall,
+)
 
 
-class ProjectContext(CognitiveContext):
-    """Execution context for this project.
-
-    Add custom fields as needed:
-    - Runtime fields (hidden from LLM): use json_schema_extra={"display": False}
-    - LLM-visible state: use EntireExposure or LayeredExposure subclasses
-    """
+# Custom context: extend with your own fields (Pydantic BaseModel under the hood).
+class AmphiContext(CognitiveContext):
     pass
+
+
+class Amphi(AmphibiousAutoma[AmphiContext]):
+    # Think unit — one observe-think-act cycle driven by an LLM.
+    main_think = think_unit(
+        CognitiveWorker.inline("Decide and execute the next step."),
+        max_attempts=10,
+    )
+
+    # Agent mode: LLM decides what to do.
+    async def on_agent(self, ctx: AmphiContext):
+        await self.main_think
+        # TODO
+
+    # Workflow mode: developer-defined deterministic steps. Implementing both
+    # on_agent and on_workflow enables AMPHIFLOW (workflow with agent fallback).
+    # Yield ActionCall / HumanCall / AgentCall to drive each step.
+    async def on_workflow(self, ctx: AmphiContext):
+        # yield ActionCall("tool_name", arg="value")
+        # feedback = yield HumanCall(prompt="Confirm?")
+        # yield AgentCall(goal="Delegate sub-task to LLM")
+        if False:
+            yield  # makes this a proper async generator
+        # TODO
 '''
 
-_AGENTS_PY = '''\
-"""Amphibious agent code.
-
-Define your AmphibiousAutoma subclass with on_agent() and on_workflow() methods here.
-"""
-
-# TODO: Implement your agent class here
-'''
-
-
-# ──────────────────────────────────────────────────────────────────────
-# Scaffolding API
-# ──────────────────────────────────────────────────────────────────────
 
 def create_project(
-    name: str,
     base_dir: Optional[str] = None,
     task: Optional[str] = None,
 ) -> Path:
-    """Create a new amphibious automa project with standard directory structure.
+    """Generate ``amphi.py`` in the target directory.
 
     Parameters
     ----------
-    name : str
-        Project directory name.
     base_dir : str, optional
-        Parent directory. Defaults to current working directory.
+        Target directory for the generated file. Defaults to the current
+        working directory.
     task : str, optional
-        Initial task description for task.md.
+        Task description, injected as a top-of-file ``# Task: ...`` comment.
+        Omitted when not provided.
 
     Returns
     -------
     Path
-        Path to the created project directory.
+        Path to the generated ``amphi.py``.
+
+    Raises
+    ------
+    FileExistsError
+        If ``amphi.py`` already exists in the target directory.
     """
     base = Path(base_dir) if base_dir else Path.cwd()
-    project_dir = base / name
+    target = base / _AMPHI_FILENAME
 
-    if project_dir.exists():
-        raise FileExistsError(f"Directory already exists: {project_dir}")
+    if target.exists():
+        raise FileExistsError(f"File already exists: {target}")
 
-    # Create directory structure
-    project_dir.mkdir(parents=True)
-    (project_dir / "skills").mkdir()
-    (project_dir / "result").mkdir()
-    (project_dir / "log").mkdir()
+    base.mkdir(parents=True, exist_ok=True)
 
-    # Write template files
-    task_text = task or "Describe your task here."
-    _write(project_dir / "task.md", _TASK_MD.format(task=task_text))
-    _write(project_dir / "config.py", _CONFIG_PY)
-    _write(project_dir / "tools.py", _TOOLS_PY)
-    _write(project_dir / "workers.py", _WORKERS_PY)
-    _write(project_dir / "agents.py", _AGENTS_PY)
+    task_comment = f"# Task: {task}\n\n" if task else ""
+    target.write_text(_AMPHI_PY.format(task_comment=task_comment), encoding="utf-8")
 
-    return project_dir
-
-
-def _write(path: Path, content: str) -> None:
-    path.write_text(textwrap.dedent(content), encoding="utf-8")
-
-
-# ──────────────────────────────────────────────────────────────────────
-# CLI entry point: bridgic-amphibious <command> [options]
-# ──────────────────────────────────────────────────────────────────────
-
-def _print_tree(project_dir: Path) -> None:
-    """Print the project directory tree."""
-    print(f"\nProject structure:")
-    for root, dirs, files in os.walk(project_dir):
-        # Skip __pycache__
-        dirs[:] = [d for d in dirs if d != "__pycache__"]
-        level = len(Path(root).relative_to(project_dir).parts)
-        indent = "  " * level
-        print(f"{indent}{Path(root).name}/")
-        for f in sorted(files):
-            print(f"{indent}  {f}")
+    return target
 
 
 def _cmd_create(args) -> None:
-    """Handle the 'create' subcommand."""
     try:
-        project_dir = create_project(args.name, args.base_dir, args.task)
-        print(f"Created project: {project_dir}")
-        _print_tree(project_dir)
+        path = create_project(args.base_dir, args.task)
+        print(f"Created: {path}")
     except FileExistsError as e:
         print(f"Error: {e}")
         raise SystemExit(1)
@@ -192,29 +129,24 @@ def cli() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent("""\
             examples:
-              bridgic-amphibious create -n my_project
-              bridgic-amphibious create -n my_project --task "Navigate to example.com"
+              bridgic-amphibious create
+              bridgic-amphibious create --task "Navigate to example.com"
         """),
     )
     subparsers = parser.add_subparsers(dest="command", help="available commands")
 
-    # ── create ──
     create_parser = subparsers.add_parser(
         "create",
-        help="Create a new Amphibious Automa project",
-        description="Scaffold a project with standard directory structure (task.md, config.py, tools.py, workers.py, agents.py, etc.).",
-    )
-    create_parser.add_argument(
-        "-n", "--name", required=True,
-        help="Project directory name",
+        help="Generate amphi.py in the current directory",
+        description="Generate a single amphi.py stub in the target directory.",
     )
     create_parser.add_argument(
         "--base-dir", default=None,
-        help="Parent directory (default: current directory)",
+        help="Target directory (default: current directory)",
     )
     create_parser.add_argument(
         "--task", default=None,
-        help="Initial task description for task.md",
+        help="Task description, injected as a top-of-file comment",
     )
 
     args = parser.parse_args()

--- a/packages/bridgic-amphibious/tests/test_scaffold.py
+++ b/packages/bridgic-amphibious/tests/test_scaffold.py
@@ -1,0 +1,86 @@
+"""Tests for the bridgic-amphibious project scaffolding CLI."""
+
+import ast
+import os
+
+import pytest
+
+from bridgic.amphibious.scaffold import _AMPHI_FILENAME, create_project
+
+
+class TestCreateProject:
+
+    def test_generates_only_amphi_py(self, tmp_path):
+        """The scaffold writes exactly one file and creates no subdirectories."""
+        path = create_project(base_dir=str(tmp_path))
+
+        entries = sorted(os.listdir(tmp_path))
+        assert entries == [_AMPHI_FILENAME]
+        assert path == tmp_path / _AMPHI_FILENAME
+        assert path.is_file()
+
+        # Sanity: none of the legacy files / dirs should appear
+        for legacy in ("task.md", "config.py", "tools.py", "workers.py",
+                       "agents.py", "skills", "result", "log",
+                       ".env", ".env.example"):
+            assert not (tmp_path / legacy).exists(), f"{legacy} should not be generated"
+
+    def test_amphi_py_is_compilable(self, tmp_path):
+        """The generated file must be syntactically valid Python."""
+        path = create_project(base_dir=str(tmp_path))
+        source = path.read_text(encoding="utf-8")
+        ast.parse(source)  # raises SyntaxError on failure
+
+    def test_amphi_py_has_no_main_block(self, tmp_path):
+        """Per design: the template must not contain a __main__ entry point."""
+        path = create_project(base_dir=str(tmp_path))
+        source = path.read_text(encoding="utf-8")
+        assert "__main__" not in source
+        assert "asyncio" not in source
+        assert "dotenv" not in source
+
+    def test_task_arg_injected_as_comment(self, tmp_path):
+        """--task injects a top-of-file '# Task: ...' comment."""
+        path = create_project(base_dir=str(tmp_path), task="Navigate to example.com")
+        source = path.read_text(encoding="utf-8")
+        assert source.startswith("# Task: Navigate to example.com\n")
+
+    def test_no_task_arg_omits_comment(self, tmp_path):
+        """Without --task, no '# Task:' comment is emitted."""
+        path = create_project(base_dir=str(tmp_path))
+        source = path.read_text(encoding="utf-8")
+        assert "# Task:" not in source
+
+    def test_fails_when_amphi_py_already_exists(self, tmp_path):
+        """A second invocation in the same directory must not clobber an existing file."""
+        create_project(base_dir=str(tmp_path))
+        with pytest.raises(FileExistsError):
+            create_project(base_dir=str(tmp_path))
+
+    def test_creates_base_dir_if_missing(self, tmp_path):
+        """A non-existent base_dir is created on demand."""
+        target = tmp_path / "nested" / "deep"
+        assert not target.exists()
+        path = create_project(base_dir=str(target))
+        assert path.is_file()
+        assert path.parent == target
+
+    def test_template_surfaces_core_architecture(self, tmp_path):
+        """The template should expose the framework's main building blocks so a
+        user discovers the architecture by reading it."""
+        path = create_project(base_dir=str(tmp_path))
+        source = path.read_text(encoding="utf-8")
+
+        # Custom Context subclass
+        assert "class AmphiContext(CognitiveContext):" in source
+        # AmphibiousAutoma subclass parameterized on the custom context
+        assert "class Amphi(AmphibiousAutoma[AmphiContext]):" in source
+        # think_unit declaration with a CognitiveWorker
+        assert "think_unit(" in source
+        assert "CognitiveWorker.inline(" in source
+        # Both lifecycle methods present (defines AMPHIFLOW resolution)
+        assert "async def on_agent(self, ctx" in source
+        assert "async def on_workflow(self, ctx" in source
+        # Workflow primitives imported (referenced in commented hints)
+        for name in ("ActionCall", "AgentCall", "HumanCall"):
+            assert name in source, f"{name} should be visible in the template"

--- a/packages/bridgic-amphibious/tests/test_stub_override_robustness.py
+++ b/packages/bridgic-amphibious/tests/test_stub_override_robustness.py
@@ -1,0 +1,273 @@
+"""Robustness tests for AI-generated stub overrides of template methods.
+
+When AI coding tools generate skeleton subclasses, they often emit::
+
+    async def before_action(self, decision_result, ctx): pass
+    async def after_action(self, step_result, ctx): pass
+    async def on_workflow(self, ctx): pass
+
+These should NOT crash the framework. The contracts are:
+
+- Worker-level ``before_action`` / ``after_action`` returning ``None`` is treated
+  identically to ``_DELEGATE`` (delegate to the agent-level hook).
+- Agent-level ``before_action`` returning ``None`` is treated as a passthrough
+  (the original ``decision_result`` is preserved).
+- ``on_workflow`` written as a plain ``async def ... : pass`` (a coroutine, not
+  an async generator) is treated as "not overridden" — ``_has_workflow()``
+  returns False and ``RunMode.AUTO`` falls back to the agent path.
+"""
+
+from typing import Any, AsyncGenerator, List, Union
+from unittest.mock import MagicMock
+
+import pytest
+
+from bridgic.amphibious import (
+    ActionCall,
+    AgentCall,
+    AmphibiousAutoma,
+    CognitiveContext,
+    CognitiveWorker,
+    HumanCall,
+    RunMode,
+    StepToolCall,
+    ToolArgument,
+)
+from .tools import get_travel_planning_tools
+
+
+ThinkDecision = CognitiveWorker._create_think_model(
+    enable_rehearsal=False,
+    enable_reflection=False,
+    enable_acquiring=False,
+    output_schema=None,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock LLM
+# ---------------------------------------------------------------------------
+
+class _SeqLLM:
+    """Returns a fixed sequence of structured-output responses."""
+
+    def __init__(self, responses: List[Any]):
+        self._responses = list(responses)
+        self._idx = 0
+
+    async def astructured_output(self, messages, constraint, **kwargs):
+        resp = self._responses[self._idx % len(self._responses)]
+        self._idx += 1
+        return resp
+
+    async def achat(self, messages, **kwargs): return MagicMock()
+    async def astream(self, messages, **kwargs): return MagicMock()
+    def chat(self, messages, **kwargs): return MagicMock()
+    def stream(self, messages, **kwargs): return MagicMock()
+
+
+class _TravelCtx(CognitiveContext):
+    def __post_init__(self):
+        for t in get_travel_planning_tools():
+            self.tools.add(t)
+
+
+def _search_decision(finish: bool = False) -> ThinkDecision:
+    return ThinkDecision(
+        step_content="Search for flights",
+        output=[
+            StepToolCall(
+                tool="search_flights",
+                tool_arguments=[
+                    ToolArgument(name="origin", value="Beijing"),
+                    ToolArgument(name="destination", value="Tokyo"),
+                    ToolArgument(name="date", value="2024-06-01"),
+                ],
+            )
+        ],
+        finish=finish,
+    )
+
+
+# ---------------------------------------------------------------------------
+# on_workflow stub (`pass` body) — coroutine, not async generator
+# ---------------------------------------------------------------------------
+
+class TestOnWorkflowStub:
+
+    def test_pass_body_makes_has_workflow_return_false(self):
+        """`async def on_workflow(...): pass` is a coroutine, not async-gen → not a real override."""
+
+        class StubAgent(AmphibiousAutoma[CognitiveContext]):
+            async def on_workflow(self, ctx):  # noqa: D401 — stub
+                pass
+
+            async def on_agent(self, ctx):
+                pass
+
+        agent = StubAgent(llm=_SeqLLM([]))
+        assert agent._has_workflow() is False
+        assert agent._has_agent() is True
+
+    def test_real_async_generator_still_detected(self):
+        """A real `yield`-bearing override is still recognized as workflow."""
+
+        class WorkflowAgent(AmphibiousAutoma[CognitiveContext]):
+            async def on_workflow(
+                self, ctx
+            ) -> AsyncGenerator[Union[ActionCall, HumanCall, AgentCall], None]:
+                if False:  # pragma: no cover
+                    yield
+
+        agent = WorkflowAgent(llm=_SeqLLM([]))
+        assert agent._has_workflow() is True
+
+    def test_auto_mode_resolves_to_agent_when_workflow_is_stub(self):
+        """RunMode.AUTO should pick AGENT when on_workflow is a `pass` stub but on_agent is real."""
+
+        class StubAgent(AmphibiousAutoma[CognitiveContext]):
+            async def on_workflow(self, ctx):
+                pass
+
+            async def on_agent(self, ctx):
+                pass
+
+        agent = StubAgent(llm=_SeqLLM([]))
+        assert agent._resolve_mode(RunMode.AUTO) is RunMode.AGENT
+
+    def test_only_stub_workflow_no_agent_raises(self):
+        """If both hooks are absent (workflow is a stub, agent not overridden), surface the existing RuntimeError."""
+
+        class OnlyStubAgent(AmphibiousAutoma[CognitiveContext]):
+            async def on_workflow(self, ctx):
+                pass
+
+        agent = OnlyStubAgent(llm=_SeqLLM([]))
+        with pytest.raises(RuntimeError, match="must override on_agent\\(\\) or on_workflow\\(\\)"):
+            agent._resolve_mode(RunMode.AUTO)
+
+    @pytest.mark.asyncio
+    async def test_arun_does_not_crash_on_stub_workflow(self):
+        """End-to-end: `arun()` with a `pass`-body on_workflow runs via on_agent without errors."""
+
+        on_agent_calls = []
+        llm = _SeqLLM([_search_decision(finish=True)])
+
+        class StubWorkflowAgent(AmphibiousAutoma[_TravelCtx]):
+            async def on_workflow(self, ctx):  # AI-generated stub
+                pass
+
+            async def on_agent(self, ctx):
+                on_agent_calls.append(ctx.goal)
+                worker = CognitiveWorker.inline("Plan step.", llm=self.llm)
+                await self._run(worker, max_attempts=1)
+
+        agent = StubWorkflowAgent(llm=llm)
+        await agent.arun(goal="Trigger fallback to on_agent")
+
+        assert on_agent_calls == ["Trigger fallback to on_agent"]
+
+
+# ---------------------------------------------------------------------------
+# Worker-level before_action / after_action stubs returning None
+# ---------------------------------------------------------------------------
+
+class TestWorkerHookStubs:
+
+    @pytest.mark.asyncio
+    async def test_worker_before_action_pass_delegates_to_agent(self):
+        """Worker `before_action` returning None must chain to agent-level hook (not drop decision)."""
+
+        agent_before_calls = []
+        llm = _SeqLLM([_search_decision(finish=True)])
+
+        class StubWorker(CognitiveWorker):
+            async def thinking(self):
+                return "Plan ONE step"
+
+            async def before_action(self, decision_result, context):  # noqa: D401 — stub
+                pass
+
+        worker = StubWorker(llm=llm)
+
+        class StubAgent(AmphibiousAutoma[_TravelCtx]):
+            async def before_action(self, decision_result, ctx):
+                agent_before_calls.append(decision_result)
+                return decision_result
+
+            async def on_agent(self, ctx):
+                await self._run(worker, max_attempts=1)
+
+        agent = StubAgent(llm=llm)
+        await agent.arun(goal="Trigger before_action delegation")
+
+        # Agent-level before_action ran exactly once with the original tool list.
+        assert len(agent_before_calls) == 1
+        decision = agent_before_calls[0]
+        assert isinstance(decision, list) and len(decision) == 1
+        tool_call, _spec = decision[0]
+        assert tool_call.name == "search_flights"
+
+        # The tool actually executed (proves decision_result wasn't replaced with None).
+        last_step = agent._current_context.cognitive_history[-1]
+        tool_names = [r.tool_name for r in last_step.result.results]
+        assert tool_names == ["search_flights"]
+
+    @pytest.mark.asyncio
+    async def test_worker_after_action_pass_delegates_to_agent(self):
+        """Worker `after_action` returning None must still chain to agent-level after_action."""
+
+        agent_after_calls = []
+        llm = _SeqLLM([_search_decision(finish=True)])
+
+        class StubWorker(CognitiveWorker):
+            async def thinking(self):
+                return "Plan ONE step"
+
+            async def after_action(self, step_result, ctx):  # noqa: D401 — stub
+                pass
+
+        worker = StubWorker(llm=llm)
+
+        class StubAgent(AmphibiousAutoma[_TravelCtx]):
+            async def after_action(self, step_result, ctx):
+                agent_after_calls.append(step_result)
+
+            async def on_agent(self, ctx):
+                await self._run(worker, max_attempts=1)
+
+        agent = StubAgent(llm=llm)
+        await agent.arun(goal="Trigger after_action delegation")
+
+        assert len(agent_after_calls) == 1, (
+            "Agent-level after_action should run when worker returns None"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Agent-level before_action stub returning None
+# ---------------------------------------------------------------------------
+
+class TestAgentBeforeActionStub:
+
+    @pytest.mark.asyncio
+    async def test_agent_before_action_pass_passes_through_decision(self):
+        """Agent-level `before_action` returning None preserves the original decision_result."""
+
+        llm = _SeqLLM([_search_decision(finish=True)])
+        worker = CognitiveWorker.inline("Plan step.", llm=llm)
+
+        class StubAgent(AmphibiousAutoma[_TravelCtx]):
+            async def before_action(self, decision_result, ctx):  # noqa: D401 — stub
+                pass
+
+            async def on_agent(self, ctx):
+                await self._run(worker, max_attempts=1)
+
+        agent = StubAgent(llm=llm)
+        await agent.arun(goal="Trigger agent before_action passthrough")
+
+        # The original tool call survives the None-returning hook and executes.
+        last_step = agent._current_context.cognitive_history[-1]
+        tool_names = [r.tool_name for r in last_step.result.results]
+        assert tool_names == ["search_flights"]

--- a/packages/bridgic-amphibious/tests/test_stub_override_robustness.py
+++ b/packages/bridgic-amphibious/tests/test_stub_override_robustness.py
@@ -5,13 +5,16 @@ When AI coding tools generate skeleton subclasses, they often emit::
     async def before_action(self, decision_result, ctx): pass
     async def after_action(self, step_result, ctx): pass
     async def on_workflow(self, ctx): pass
+    async def observation(self, context): pass
+    async def action_custom_output(self, decision_result, ctx): pass
 
 These should NOT crash the framework. The contracts are:
 
-- Worker-level ``before_action`` / ``after_action`` returning ``None`` is treated
-  identically to ``_DELEGATE`` (delegate to the agent-level hook).
-- Agent-level ``before_action`` returning ``None`` is treated as a passthrough
-  (the original ``decision_result`` is preserved).
+- Worker-level ``before_action`` / ``after_action`` / ``observation`` returning
+  ``None`` is treated identically to ``_DELEGATE`` (delegate to the agent-level
+  hook).
+- Agent-level ``before_action`` and ``action_custom_output`` returning ``None``
+  are treated as passthrough (the original input is preserved).
 - ``on_workflow`` written as a plain ``async def ... : pass`` (a coroutine, not
   an async generator) is treated as "not overridden" — ``_has_workflow()``
   returns False and ``RunMode.AUTO`` falls back to the agent path.
@@ -271,3 +274,92 @@ class TestAgentBeforeActionStub:
         last_step = agent._current_context.cognitive_history[-1]
         tool_names = [r.tool_name for r in last_step.result.results]
         assert tool_names == ["search_flights"]
+
+
+# ---------------------------------------------------------------------------
+# Worker-level observation stub returning None
+# ---------------------------------------------------------------------------
+
+class TestWorkerObservationStub:
+
+    @pytest.mark.asyncio
+    async def test_worker_observation_pass_falls_back_to_agent(self):
+        """Worker-level `observation` returning None must delegate to agent-level."""
+
+        llm = _SeqLLM([_search_decision(finish=True)])
+
+        class StubWorker(CognitiveWorker):
+            async def thinking(self):
+                return "Plan ONE step"
+
+            async def observation(self, context):  # noqa: D401 — stub
+                pass
+
+        worker = StubWorker(llm=llm)
+
+        class StubAgent(AmphibiousAutoma[_TravelCtx]):
+            async def observation(self, ctx):
+                return "agent-level observation"
+
+            async def on_agent(self, ctx):
+                await self._run(worker, max_attempts=1)
+
+        agent = StubAgent(llm=llm)
+        await agent.arun(goal="Trigger observation delegation")
+
+        # Agent-level observation wins instead of the worker silently writing
+        # ``None`` into ctx.observation.
+        assert agent._current_context.observation == "agent-level observation"
+
+
+# ---------------------------------------------------------------------------
+# Agent-level action_custom_output stub returning None
+# ---------------------------------------------------------------------------
+
+from pydantic import BaseModel
+
+
+class _PlanOutput(BaseModel):
+    note: str
+
+
+class TestActionCustomOutputStub:
+
+    @pytest.mark.asyncio
+    async def test_action_custom_output_pass_passes_through(self):
+        """Agent-level `action_custom_output` returning None preserves the typed output."""
+
+        expected = _PlanOutput(note="should be preserved")
+
+        class _PlanWorker(CognitiveWorker):
+            output_schema = _PlanOutput
+
+            async def thinking(self):
+                return "Produce a plan."
+
+        worker = _PlanWorker(llm=_SeqLLM([]))
+        decision_model = worker._ThinkDecisionModel
+        decision = decision_model(
+            step_content="Planning complete",
+            output=expected,
+            finish=True,
+        )
+
+        llm = _SeqLLM([decision])
+        worker.set_llm(llm)
+
+        class StubAgent(AmphibiousAutoma[CognitiveContext]):
+            async def action_custom_output(self, decision_result, ctx):  # noqa: D401 — stub
+                pass
+
+            async def on_agent(self, ctx):
+                await self._run(worker, max_attempts=1)
+
+        agent = StubAgent(llm=llm)
+        await agent.arun(goal="Trigger action_custom_output passthrough")
+
+        # The typed output survives a None-returning override.
+        last_step = agent._current_context.cognitive_history[-1]
+        assert last_step.result is expected
+        assert isinstance(last_step.result, _PlanOutput)
+        assert last_step.result.note == "should be preserved"

--- a/packages/bridgic-amphibious/tests/test_workflow_helper_error.py
+++ b/packages/bridgic-amphibious/tests/test_workflow_helper_error.py
@@ -1,0 +1,139 @@
+"""Tests for generator-internal exceptions raised inside ``on_workflow``.
+
+When user code between yields (helpers, conditionals, parameter prep) raises,
+the framework cannot resume the generator (asend() would raise StopIteration).
+The expected behavior is mode-dependent:
+
+- WORKFLOW (pure, no on_agent override): re-raise the original exception
+- AMPHIFLOW (on_agent overridden): hand the remaining task to on_agent(ctx)
+- AMPHIFLOW without on_agent override: explicit RuntimeError
+
+These tests cover the exception path added in ``_run_workflow``'s inner try
+around ``gen.__anext__()`` / ``gen.asend()``.
+"""
+
+from typing import AsyncGenerator, Union
+
+import pytest
+
+from bridgic.amphibious import (
+    AmphibiousAutoma,
+    CognitiveContext,
+    CognitiveWorker,
+    ActionCall,
+    HumanCall,
+    AgentCall,
+    StepToolCall,
+    ToolArgument,
+)
+
+
+ThinkDecision = CognitiveWorker._create_think_model(
+    enable_rehearsal=False,
+    enable_reflection=False,
+    enable_acquiring=False,
+    output_schema=None,
+)
+
+
+class _MockLLM:
+    """Returns a fixed sequence of structured-output responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self._idx = 0
+
+    async def astructured_output(self, messages, constraint, **kwargs):
+        resp = self._responses[self._idx % len(self._responses)]
+        self._idx += 1
+        return resp
+
+    async def achat(self, messages, **kwargs): ...
+    async def astream(self, messages, **kwargs): ...
+    def chat(self, messages, **kwargs): ...
+    def stream(self, messages, **kwargs): ...
+
+
+def _finish_decision() -> ThinkDecision:
+    return ThinkDecision(
+        step_content="Recovered",
+        output=[],
+        finish=True,
+    )
+
+
+class TestWorkflowGeneratorError:
+
+    @pytest.mark.asyncio
+    async def test_helper_raises_in_workflow_mode_propagates(self):
+        """Pure WORKFLOW mode: a helper exception inside on_workflow propagates as-is."""
+
+        sentinel_message = "boom-from-helper"
+
+        class Agent(AmphibiousAutoma[CognitiveContext]):
+            async def on_workflow(self, ctx) -> AsyncGenerator[
+                Union[ActionCall, HumanCall, AgentCall], None
+            ]:
+                # Generator raises before any yield — equivalent to a helper
+                # call between yields blowing up.
+                raise ValueError(sentinel_message)
+                yield  # pragma: no cover
+
+        agent = Agent()  # No on_agent override → resolved as RunMode.WORKFLOW
+
+        with pytest.raises(ValueError, match=sentinel_message):
+            await agent.arun(goal="Trigger helper failure")
+
+    @pytest.mark.asyncio
+    async def test_helper_raises_in_amphiflow_falls_back_to_on_agent(self):
+        """AMPHIFLOW mode: a helper exception routes execution to on_agent(ctx)."""
+
+        on_agent_calls = []
+        llm = _MockLLM([_finish_decision()])
+
+        class Agent(AmphibiousAutoma[CognitiveContext]):
+            async def on_agent(self, ctx):
+                on_agent_calls.append(ctx.goal)
+                worker = CognitiveWorker.inline("Recover.", llm=self.llm)
+                await self._run(worker, max_attempts=1)
+
+            async def on_workflow(self, ctx) -> AsyncGenerator[
+                Union[ActionCall, HumanCall, AgentCall], None
+            ]:
+                raise RuntimeError("simulated helper failure")
+                yield  # pragma: no cover
+
+        agent = Agent(llm=llm)
+        # arun should not raise — fallback handles it.
+        await agent.arun(goal="Trigger amphiflow fallback")
+
+        assert len(on_agent_calls) == 1, (
+            f"on_agent should have been invoked exactly once for the fallback, "
+            f"got {len(on_agent_calls)} invocations"
+        )
+
+    @pytest.mark.asyncio
+    async def test_helper_raises_in_workflow_without_agent_raises_clear_error(self):
+        """No on_agent override + AMPHIFLOW forced: must surface a clear RuntimeError.
+
+        We force AMPHIFLOW via mode= since auto-resolution would pick WORKFLOW
+        when on_agent is not overridden. This isolates the ``not self._has_agent()``
+        branch on the new generator-error path.
+        """
+        from bridgic.amphibious import RunMode
+
+        class Agent(AmphibiousAutoma[CognitiveContext]):
+            async def on_workflow(self, ctx) -> AsyncGenerator[
+                Union[ActionCall, HumanCall, AgentCall], None
+            ]:
+                raise KeyError("missing key")
+                yield  # pragma: no cover
+
+        # Forced AMPHIFLOW requires an LLM at startup, even though we never reach it.
+        agent = Agent(llm=_MockLLM([]))
+
+        with pytest.raises(RuntimeError, match="on_agent\\(\\) is not overridden"):
+            await agent.arun(
+                goal="Trigger amphiflow without agent",
+                mode=RunMode.AMPHIFLOW,
+            )

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,101 @@
+# Bridgic Skills
+
+Self-contained capability modules that Claude (or any skill-aware agent) loads on demand. Each skill bundles a `SKILL.md` (what the skill does and when to use it), supporting references, and a dependency-bootstrap script — so a caller can install everything the skill needs into their own uv-managed project with a single command.
+
+## Available skills
+
+| Skill | Purpose |
+|-------|---------|
+| [`bridgic-amphibious`](./bridgic-amphibious) | Dual-mode agent framework — combines LLM-driven (`on_agent`) and deterministic (`on_workflow`) execution with automatic fallback and human-in-the-loop support. |
+| [`bridgic-llms`](./bridgic-llms) | LLM provider initialization — `bridgic-llms-openai`, `bridgic-llms-openai-like`, `bridgic-llms-vllm`, exposed through a unified `BaseLlm` + protocol interface. |
+
+Each skill's own `SKILL.md` is the authoritative source for its API, quickstart, and usage boundaries.
+
+## Directory layout
+
+Every skill follows the same structure:
+
+```
+skills/<skill-name>/
+├── SKILL.md                 # purpose, quickstart, when-to-use (read by Claude)
+├── references/              # extra docs, examples, templates
+└── scripts/
+    ├── install-deps.sh      # dependency bootstrap (shared grammar across skills)
+    ├── deps.ini             # single-variant skill
+    └── deps.<variant>.ini   # one file per variant (e.g. LLM provider)
+```
+
+`install-deps.sh` and the `deps*.ini` format are identical across skills, so once you understand one you understand all of them.
+
+## Running a skill's installer
+
+```bash
+# single-variant skill (bridgic-amphibious)
+bash skills/<skill>/scripts/install-deps.sh <project-dir>
+
+# multi-variant skill (bridgic-llms — default variant is "openai")
+bash skills/<skill>/scripts/install-deps.sh <project-dir> <variant>
+```
+
+The script will: auto-install `uv` if missing → `uv init --bare` if `<project-dir>` has no `pyproject.toml` → `uv add` any missing packages and re-pin those with an explicit `version` → `uv sync`.
+
+Outcome markers (grep-friendly):
+
+- Success: `=== DEPS_READY (...) ===`
+- Failure: `=== DEPS_FAILED reason=<label> exit=<N> ===`
+
+When the script exits 0 the target project is fully initialized — no follow-up `uv add` / `uv sync` required.
+
+## `deps.ini` format
+
+Per-variant dependency manifest. Standard INI:
+
+- `[section]` — section name **is** the pip package name
+- `key = value` inside a section — only `source` and `version` are recognized
+- Comments: full-line `#` or `;`; blank lines OK
+- Values may be quoted with `"..."` (quotes are stripped)
+- Unknown key, key outside a section, or malformed line → fatal (exit 5)
+
+### Fields
+
+| Key | Required | Default | Meaning |
+|-----|----------|---------|---------|
+| `source` | no | `"default"` | Must be `"default"` (public PyPI) for anything shipped to `main`. |
+| `version` | no | (none) | PEP 440 specifier, e.g. `">=1.0,<2.0"` or `"==0.5.2"`. If set, the package is **re-pinned to this constraint on every run**; if unset, install latest only when missing. |
+
+### Example
+
+```ini
+# Public PyPI, latest
+[bridgic-core]
+source = "default"
+
+# Public PyPI, pinned
+[python-dotenv]
+source = "default"
+version = ">=1.0,<2.0"
+```
+
+## CI gate
+
+The `Skill Install-Deps Check` workflow runs on every PR targeting `main` and, for each `deps*.ini` found under `skills/*/scripts/`:
+
+1. **Policy guard** — rejects any section whose `source` is not `"default"`, listing every offender with a clear message.
+2. **Live bootstrap** — runs `install-deps.sh` in a fresh `mktemp -d` project dir and asserts `=== DEPS_READY` reaches stdout. This validates INI syntax, package name correctness, and version resolvability against public PyPI.
+
+The matrix is discovered dynamically by scanning `skills/*/scripts/deps*.ini` — adding a new skill or variant needs **no** workflow change.
+
+## Exit codes
+
+| Code | Reason |
+|------|--------|
+| 1 | `uv` not installed or not on PATH after install attempt |
+| 2 | `uv init` failed |
+| 3 | `uv add` failed |
+| 4 | `uv sync` failed |
+| 5 | `deps.ini` missing, malformed, or empty |
+
+## Not supported
+
+- `extras` (e.g. `pkg[openai]`) — workaround: depend on the extras-bearing meta-package directly
+- markers / environment conditions

--- a/skills/bridgic-amphibious/SKILL.md
+++ b/skills/bridgic-amphibious/SKILL.md
@@ -13,7 +13,7 @@ A bridgic-amphibious project requires the following packages:
 
 | Package | Description |
 |---------|-------------|
-| `bridgic-core` | Core framework (Worker, Automa, GraphAutoma, ASL) |
+| `bridgic-core` | Core framework (Worker, Automa, GraphAutoma) |
 | `bridgic-amphibious` | Dual-mode agent framework |
 | `bridgic-llms-openai` | LLM provider (only required for `AGENT` / `AMPHIFLOW` modes) |
 | `python-dotenv` | `.env` file loading |
@@ -74,12 +74,12 @@ result = await agent.arun(
 Use the CLI to bootstrap a new project:
 
 ```bash
-bridgic-amphibious create -n my_project
-bridgic-amphibious create -n my_project --task "Navigate to example.com and extract data"
-bridgic-amphibious create -n my_project --base-dir /path/to/projects
+bridgic-amphibious create
+bridgic-amphibious create --task "Navigate to example.com and extract data"
+bridgic-amphibious create --base-dir /path/to/project
 ```
 
-Creates: `task.md`, `config.py`, `tools.py`, `workers.py`, `agents.py`, `skills/`, `result/`, `log/`.
+Creates a single `amphi.py` in the target directory (default: cwd). The template includes a custom `CognitiveContext` subclass, an `AmphibiousAutoma` subclass with a `think_unit` declaration, and stubs for both `on_agent` and `on_workflow`. Runtime concerns (LLM credentials, entry script) are intentionally left to the caller.
 
 ## Core Concepts
 

--- a/skills/bridgic-amphibious/references/api-reference.md
+++ b/skills/bridgic-amphibious/references/api-reference.md
@@ -86,29 +86,23 @@ from bridgic.core.model.types import Message
 Bootstrap a new amphibious project:
 
 ```bash
-bridgic-amphibious create -n <project-name> [--base-dir <path>] [--task <description>]
+bridgic-amphibious create [--base-dir <path>] [--task <description>]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-n, --name` | (required) | Project directory name |
-| `--base-dir` | Current directory | Parent directory for the project |
-| `--task` | "Describe your task here." | Initial task description for `task.md` |
+| `--base-dir` | Current directory | Target directory for the generated file |
+| `--task` | (omitted) | Injected as a top-level `# Task: ...` comment in `amphi.py` |
 
-Generated structure:
+Generated file:
 
 ```
-<project-name>/
-├── task.md          # Task description (input)
-├── config.py        # LLM configuration (API base, key, model)
-├── tools/           # Tool definitions
-│   └── __init__.py
-├── workers.py       # Context and data models (ProjectContext)
-├── agents.py        # AmphibiousAutoma subclass (TODO template)
-├── skills/          # Amphibious skills
-├── result/          # Trace and analysis results
-└── log/             # Runtime logs
+amphi.py    # AmphibiousAutoma stub: AmphiContext + Amphi class with think_unit, on_agent, on_workflow
 ```
+
+The scaffold writes only this single file in the target directory. It does not create subdirectories and does not emit runtime configuration (e.g. `.env`) — those concerns belong to the caller's environment, not the scaffold.
+
+Python API: `create_project(base_dir: Optional[str] = None, task: Optional[str] = None) -> Path`. Raises `FileExistsError` if `amphi.py` already exists in the target directory.
 
 ## AmphibiousAutoma
 

--- a/skills/bridgic-amphibious/references/architecture.md
+++ b/skills/bridgic-amphibious/references/architecture.md
@@ -186,12 +186,22 @@ async with self.snapshot(goal="Sub-task A"):
 
 ## Workflow Fallback Mechanism
 
-In AMPHIFLOW mode:
+Two distinct failure sources are handled in AMPHIFLOW mode:
 
-1. Deterministic step fails → check `consecutive_failures < max_consecutive_fallbacks`
-2. If within limit: agent fixes the specific step (scoped goal via `snapshot`)
-3. If exceeded: abandon workflow → call `on_agent()` for full agent mode
-4. `AgentCall` yield explicitly delegates a sub-task to agent mode (with a clean context snapshot)
+**ActionCall tool failure** (a yielded tool raises during execution):
+
+1. Step fails → check `consecutive_failures < max_consecutive_fallbacks`
+2. Within limit: agent fixes the specific step (scoped goal via `snapshot`); generator resumes
+3. Limit exceeded: abandon workflow → call `on_agent()` for full agent mode
+
+**Generator-internal exception** (helper / inline logic between yields raises):
+
+- The generator is unrecoverable after a raise — `asend()` cannot resume it — so step-level fallback is impossible. The framework jumps directly to full fallback: `on_agent(ctx)` takes over the remaining task.
+- Pure WORKFLOW mode (`will_fallback=False`): the original exception is re-raised — no fallback.
+- AMPHIFLOW with `on_agent` overridden: hand off to `on_agent(ctx)`.
+- AMPHIFLOW forced via `mode=` without an `on_agent` override: a `RuntimeError` is raised, tagged with the failing step index.
+
+`AgentCall` yield is orthogonal to fallback — it explicitly delegates a sub-task to agent mode (with a clean context snapshot) regardless of failure state.
 
 ## Human-in-the-Loop
 


### PR DESCRIPTION
## Summary

This branch bundles two related streams of work that landed under
`fix/skills-and-amphibious-fallback`:

1. **Amphibious robustness** — make the framework tolerate two classes of
   user-code shape that previously crashed it.
2. **Skills + scaffold realignment** — collapse the scaffold to a single
   `amphi.py` and update the `bridgic-amphibious` skill docs to match.

A new CI gate is also added so PRs to `main` cannot ship with a broken
skills `install-deps` step.

### Amphibious robustness

- `on_workflow` helper exceptions (anything raised between yields) are
  now caught and routed:
  - **WORKFLOW** mode → original exception is re-raised as-is.
  - **AMPHIFLOW** mode → execution falls back to `on_agent(ctx)`.
  - Forced AMPHIFLOW without an `on_agent` override → clear `RuntimeError`.
- AI-generated stub overrides no longer break the framework:
  - Worker-level `before_action` / `after_action` returning `None` is
    treated identically to `_DELEGATE` (delegate to the agent-level hook).
  - Agent-level `before_action` returning `None` is treated as passthrough
    (the original `decision_result` is preserved).
  - `async def on_workflow(...): pass` (a coroutine, not an async
    generator) is now recognized as *not overridden* via
    `inspect.isasyncgenfunction`, so `RunMode.AUTO` falls back to the
    agent path instead of crashing on the generator protocol.

### Skills & scaffold

- `scaffold.py` simplified to emit a single `amphi.py` with an
  architecture stub.
- `skills/bridgic-amphibious/SKILL.md` and the `architecture` /
  `api-reference` documents updated to match the new scaffold and the
  helper-error semantics above.
- New top-level `skills/README.md`.

### CI

- New workflow `.github/workflows/skill-install-deps-check.yml` that
  gates PRs targeting `main` on a successful skills `install-deps` run.

## Test plan

- [x] `uv run pytest -q` (97 passed, including 8 new stub-override
      tests in `tests/test_stub_override_robustness.py` and 3 helper-error
      tests in `tests/test_workflow_helper_error.py`)
- [ ] CI: `skill-install-deps-check` runs green against this branch
- [ ] Spot-check that a freshly scaffolded project (`amphi init`) still
      runs end-to-end against the updated `amphi.py` template